### PR TITLE
Update shallowCompare to accept nextContext

### DIFF
--- a/src/addons/shallowCompare.js
+++ b/src/addons/shallowCompare.js
@@ -17,10 +17,11 @@ var shallowEqual = require('shallowEqual');
  * Does a shallow comparison for props and state.
  * See ReactComponentWithPureRenderMixin
  */
-function shallowCompare(instance, nextProps, nextState) {
+function shallowCompare(instance, nextProps, nextState, nextContext) {
   return (
     !shallowEqual(instance.props, nextProps) ||
-    !shallowEqual(instance.state, nextState)
+    !shallowEqual(instance.state, nextState) ||
+    (typeof nextContext !== 'undefined' && !shallowEqual(instance.context, nextContext))
   );
 }
 


### PR DESCRIPTION
Across our application we are using immutable objects as properties and thus using shallowCompare for all our `shouldComponentUpdate`.  Because of this, children with contextTypes don't get updates when the context on the parent changes.  Adding an additional comparison for context (when it is provided) fixes this problem.